### PR TITLE
use correct branch name

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -53,7 +53,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         files: '**/*/test-results.xml'
   test-badge:
-    if: ${{ github.ref == 'master' }}
+    if: github.ref == 'ref/head/main'
     needs: test-results
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Example of correctly identifying the branch: https://github.community/t/run-step-on-if-branch-tag-is/16965

Also, this repo uses `main` not `master`.