### PR TITLE
Add support for package sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,20 @@ The command line options are as follows:
 
   -c, --config              Required. Path to the configuration file.
 
-  -r, --additional-rules    A path to a single assembly or folder of assemblies which contain additional
-                            rules.  Overrides `additionalRules` setting in JSON configuration file.
+  -r, --additional-rules    A path to a single assembly or folder of assemblies which contain additional rules.
 
   -p, --package-name        If the package name is different than the DLL file name, specify it here.
 
   --omit-disclaimer         Omits the disclaimer paragraph that appears at the top of the output.
 
   -h, --include-header      Includes a header with the assembly and package at the top of the output.
+
+  --assume-changes          Assumes that something changed, making Patch the lowest bump rather than None. Default is
+                            false.
+
+  --show-changes            Show all changes, even if the version is as expected. Default is false.
+
+  -f, --framework           Indicates the framework from the Nuget package to use as a comparison.
 
   --help                    Display this help screen.
 
@@ -54,7 +60,8 @@ dotnet analyze-semver -a path/to/MyAssembly.dll -o results.txt -c ./config.json
 - `settings`
   - `ruleOverrides` - Provides overrides for individual rules (see below).
 - `nuget`
-  - `repositoryUrl` - The URL to the Nuget feed where the existing assembly is published.
+  - `repositoryUrl` - The URL to the Nuget feed where the existing assembly is published. Mutually exclusive with `packageSource`.
+  - `packageSource` - The name of the Nuget package source where the existing assembly is published. Mutually exclusive with `repositoryUrl`.
 
 ## Built-in Rules
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,7 @@
+# v4.0.0
+
+[#65](https://github.com/pushpay-labs/semantic-versioning-analyzer/issues/65) - Add support for package sources and add show-changes
+
 # v3.0.0
 
 [#59](https://github.com/pushpay-labs/semantic-versioning-analyzer/issues/59) - Target `.net6` and `.net8` instead for `netcoreapp3.1`

--- a/source/SemVerAnalyzer/AppSettings.cs
+++ b/source/SemVerAnalyzer/AppSettings.cs
@@ -17,6 +17,7 @@ namespace Pushpay.SemVerAnalyzer
 		public bool OmitDisclaimer { get; set; }
 		public bool IncludeHeader { get; set; }
 		public bool AssumeChanges { get; set; }
+		public bool ShowChanges { get; set; }
 		public string Framework { get; set; }
 
 		public RuleOverrideType GetOverrideType(Type ruleType)

--- a/source/SemVerAnalyzer/CompareCommand.cs
+++ b/source/SemVerAnalyzer/CompareCommand.cs
@@ -31,6 +31,9 @@ namespace Pushpay.SemVerAnalyzer
 		[Option("assume-changes", HelpText = "Assumes that something changed, making Patch the lowest bump rather than None. Default is false.")]
 		public bool? AssumeChanges { get; set; }
 
+		[Option("show-changes", HelpText = "Show all changes, even if the version is as expected. Default is false.")]
+		public bool? ShowChanges { get; set; }
+
 		[Option('f', "framework", Required = false, HelpText = "Indicates the framework from the Nuget package to use as a comparison.")]
 		public string Framework { get; set; }
 

--- a/source/SemVerAnalyzer/CompareCommandRunner.cs
+++ b/source/SemVerAnalyzer/CompareCommandRunner.cs
@@ -45,7 +45,7 @@ namespace Pushpay.SemVerAnalyzer
 
 				var result = _analyzer.AnalyzeVersions(localAssembly, onlineAssembly);
 
-				if (result.ActualBump != result.CalculatedBump)
+				if (_settings.ShowChanges || result.ActualBump != result.CalculatedBump)
 				{
 					comments = result.GetAllComments();
 					if (_settings.IncludeHeader)

--- a/source/SemVerAnalyzer/NugetConfiguration.cs
+++ b/source/SemVerAnalyzer/NugetConfiguration.cs
@@ -3,5 +3,6 @@
 	internal class NugetConfiguration
 	{
 		public string RepositoryUrl { get; set; }
+		public string PackageSource { get; set; }
 	}
 }

--- a/source/SemVerAnalyzer/Program.cs
+++ b/source/SemVerAnalyzer/Program.cs
@@ -58,9 +58,9 @@ namespace Pushpay.SemVerAnalyzer
 
 			builder.RegisterInstance(appSettings).AsSelf();
 			var nugetConfig = config.GetSection("nuget").Get<NugetConfiguration>();
-			if (nugetConfig?.RepositoryUrl == null)
+			if (nugetConfig?.PackageSource == null && nugetConfig?.RepositoryUrl == null)
 			{
-				Console.WriteLine("Nuget repository missing from configuration.");
+				Console.WriteLine("NuGet package source or repository url is missing from configuration.");
 				Environment.Exit(1);
 			}
 			builder.RegisterInstance(nugetConfig).AsSelf();

--- a/source/SemVerAnalyzer/Program.cs
+++ b/source/SemVerAnalyzer/Program.cs
@@ -77,6 +77,7 @@ namespace Pushpay.SemVerAnalyzer
 			appSettings.IncludeHeader = command.IncludeHeader ?? appSettings.IncludeHeader;
 			appSettings.OmitDisclaimer = command.OmitDisclaimer ?? appSettings.OmitDisclaimer;
 			appSettings.AssumeChanges = command.AssumeChanges ?? appSettings.AssumeChanges;
+			appSettings.ShowChanges = command.ShowChanges ?? appSettings.ShowChanges;
 			appSettings.Framework = command.Framework ?? appSettings.Framework;
 		}
 	}

--- a/source/SemVerAnalyzer/SemVerAnalyzer.csproj
+++ b/source/SemVerAnalyzer/SemVerAnalyzer.csproj
@@ -7,9 +7,9 @@
     <RootNamespace>Pushpay.SemVerAnalyzer</RootNamespace>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>analyze-semver</ToolCommandName>
-    <Version>3.0.1</Version>
-    <AssemblyVersion>3.0.1.0</AssemblyVersion>
-    <FileVersion>3.0.1.0</FileVersion>
+    <Version>4.0.0</Version>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <FileVersion>4.0.0.0</FileVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/pushpay-labs/semantic-versioning-analyzer</PackageProjectUrl>
     <Authors>PushpayLabs</Authors>

--- a/source/SemVerAnalyzer/SemVerAnalyzer.csproj
+++ b/source/SemVerAnalyzer/SemVerAnalyzer.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="NuGet.Protocol" Version="6.9.1" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Resolves #57 and #58

I also switch the NuGet client implementation to use `NuGet.Protocol` instead which also facilitates usage of the global package cache and supports package sources with credentials.

In addition, I added the `show-changes` flag that would help us to see the changes even if the version was chosen correctly.