### PR TITLE
Use SemanticVersion.TryParse to allow all SemVer2 syntaxes

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -24,7 +24,7 @@ jobs:
       run: dotnet test --no-restore --verbosity normal --logger:"junit;LogFileName=test-results.xml"
     - name: Upload Unit Test Results
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Unit Test Results
         path: '**/*/test-results.xml'
@@ -41,7 +41,7 @@ jobs:
     if: success() || failure()
     steps:
     - name: Download Artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         path: artifacts
     - name: Publish Unit Test Results
@@ -57,7 +57,7 @@ jobs:
     - name: Extract Branch Name
       run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
     - name: Download Artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         path: artifacts
     - name: Get badge details

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -41,7 +41,7 @@ jobs:
     if: success() || failure()
     steps:
     - name: Download Artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: artifacts
     - name: Publish Unit Test Results

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Extract Branch Name
       run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
     - name: Download Artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: artifacts
     - name: Get badge details

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
     - run: dotnet pack source/SemVerAnalyzer.Abstractions/SemVerAnalyzer.Abstractions.csproj --configuration Release --output ${{ env.NuGetDirectory }}
 
     # Publish the NuGet package as an artifact, so they can be used in the following jobs
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: nuget
         if-no-files-found: error

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
     needs: [ run_test ]
     steps:
       # Download the NuGet package created in the previous job
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: nuget
           path: ${{ env.NuGetDirectory }}

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
 	"sdk": {
-		"version": "8.0.201"
+		"version": "8.0.201",
+        "rollForward": "latestFeature"
 	}
 }

--- a/tests/SemVerAnalyzer.Tests/SemVerAnalyzer.Tests.csproj
+++ b/tests/SemVerAnalyzer.Tests/SemVerAnalyzer.Tests.csproj
@@ -1,12 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
-
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
-
     <LangVersion>latest</LangVersion>
-
     <RootNamespace>Pushpay.SemVerAnalyzer.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/tests/SemVerAnalyzer.Tests/SemVerStringTests.cs
+++ b/tests/SemVerAnalyzer.Tests/SemVerStringTests.cs
@@ -48,5 +48,23 @@ namespace Pushpay.SemVerAnalyzer.Tests
 		{
 			PAssert.IsTrue(() => "2.3.4".GetSuggestedVersion(VersionBumpType.None) == "2.3.4");
 		}
+
+		[Fact]
+		public void SupportsTrailer()
+		{
+			PAssert.IsTrue(() => "2.3.4.0".ToSemver() != null);
+		}
+
+		[Fact]
+		public void SupportsComplexPreRelease()
+		{
+			PAssert.IsTrue(() => "2.3.4-ci.1".ToSemver() != null);
+		}
+
+		[Fact]
+		public void SupportsMetadata()
+		{
+			PAssert.IsTrue(() => "2.3.4-loc.debug+1af4d630".ToSemver() != null);
+		}
 	}
 }


### PR DESCRIPTION
We keep the regex to support trailers. Since `NuGet.Versioning` is already a transitive dependency of `NuGet.Protocol`, it was easy to do and should only be a hotfix change in my opinion. Didn't change the version yet.

Fixes https://github.com/pushpay-labs/semantic-versioning-analyzer/issues/68
Fixes https://github.com/pushpay-labs/semantic-versioning-analyzer/pull/67